### PR TITLE
[#5] Fix various memory leaks found in testing (main)

### DIFF
--- a/data_verification_utilities.cpp
+++ b/data_verification_utilities.cpp
@@ -192,10 +192,14 @@ namespace irods {
 
         // no checksum, compute one
         dataObjInp_t data_obj_inp{};
+        irods::at_scope_exit clear_data_obj{
+            [&data_obj_inp] { clearDataObjInp(&data_obj_inp); }};
         rstrcpy(data_obj_inp.objPath, _logical_path.c_str(), MAX_NAME_LEN);
         addKeyVal(&data_obj_inp.condInput, RESC_NAME_KW, _resource_name.c_str());
 
         char* checksum_pointer{};
+        irods::at_scope_exit free_checksum_pointer{
+            [&checksum_pointer] { free(checksum_pointer); }};
         const auto chksum_err = irods::server_api_call(DATA_OBJ_CHKSUM_AN, _comm, &data_obj_inp, &checksum_pointer);
         if(chksum_err < 0) {
             THROW(
@@ -207,7 +211,6 @@ namespace irods {
         }
 
         std::string checksum{checksum_pointer};
-        free(checksum_pointer);
 
         return checksum;
 

--- a/libirods_rule_engine_plugin-policy_engine-data_replication.cpp
+++ b/libirods_rule_engine_plugin-policy_engine-data_replication.cpp
@@ -71,6 +71,7 @@ namespace {
         auto repl_fcn = [&](auto& comm){
             auto ret = irods::server_api_call(DATA_OBJ_REPL_AN, _comm, &data_obj_inp, &trans_stat);
             free(trans_stat);
+            clearDataObjInp(&data_obj_inp);
             return ret;};
 
         return pc::exec_as_user(*_comm, _user_name, repl_fcn);

--- a/libirods_rule_engine_plugin-policy_engine-data_retention.cpp
+++ b/libirods_rule_engine_plugin-policy_engine-data_retention.cpp
@@ -119,8 +119,10 @@ namespace {
             addKeyVal(&obj_inp.condInput, REPL_NUM_KW, repl_num.c_str());
         }
 
-        auto trim_fcn = [&](auto& comm) {
-            return irods::server_api_call(api_index, &comm, &obj_inp);
+        auto trim_fcn = [&](auto &comm) {
+          auto res{irods::server_api_call(api_index, &comm, &obj_inp)};
+          clearDataObjInp(&obj_inp);
+          return res;
         };
 
         return pc::exec_as_user(*comm, user_name, trim_fcn);

--- a/libirods_rule_engine_plugin-policy_engine-verify_checksum.cpp
+++ b/libirods_rule_engine_plugin-policy_engine-verify_checksum.cpp
@@ -82,6 +82,8 @@ namespace {
         rstrcpy(inp.objPath,       logical_path.c_str(),  MAX_NAME_LEN);
 
         char* computed_checksum{};
+        irods::at_scope_exit free_computed_checksum{
+            [&computed_checksum] { free(computed_checksum); }};
         if(const auto ec = rsFileChksum(comm, &inp, &computed_checksum); ec < 0) {
             return ERROR(ec, fmt::format("{} :: rsFileChksum failed for {} on {}"
                          , "irods_policy_verify_checksum"


### PR DESCRIPTION
Issue quick link: #5

This PR attempts to fix several memory leaks found when running the plugin's test suite with ASAN enabled. The fixes were tested on top of #4 and then rebased onto the master branch of this repo.